### PR TITLE
cleanup: remove extra text from EULA

### DIFF
--- a/installer/branding/EULA_DRIVERS.rtf
+++ b/installer/branding/EULA_DRIVERS.rtf
@@ -613,48 +613,4 @@ If the disclaimer of warranty and limitation of liability provided above cannot\
 be given local legal effect according to their terms, reviewing courts shall\par
 apply local law that most closely approximates an absolute waiver of all civil\par
 liability in connection with the Program, unless a warranty or assumption\par
-of liability accompanies a copy of the Program in return for a fee. END OF\par
-TERMS AND CONDITIONS\par
-\par
-How to Apply These Terms to Your New Programs\par
-\par
-If you develop a new program, and you want it to be of the greatest possible\par
-use to the public, the best way to achieve this is to make it free software\par
-which everyone can redistribute and change under these terms.\par
-\par
-To do so, attach the following notices to the program. It is safest to attach\par
-them to the start of each source file to most effectively state the exclusion\par
-of warranty; and each file should have at least the "copyright" line and a\par
-pointer to where the full notice is found.\par
-\par
-<one line to give the program's name and a brief idea of what it does.>\par
-\par
-Copyright (C) <year> <name of author>\par
-\par
-This program is free software: you can redistribute it and/or modify it under\par
-the terms of the GNU Affero General Public License as published by the Free\par
-Software Foundation, either version 3 of the License, or (at your option)\par
-any later version.\par
-\par
-This program is distributed in the hope that it will be useful, but WITHOUT\par
-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS\par
-FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more\par
-details.\par
-\par
-You should have received a copy of the GNU Affero General Public License along\par
-with this program. If not, see <{{\field{\*\fldinst{HYPERLINK "https://www.gnu.org/licenses/"}}{\fldrslt{https://www.gnu.org/licenses/\ul0\cf0}}}}\f0\fs16 >.\par
-\par
-Also add information on how to contact you by electronic and paper mail.\par
-\par
-If your software can interact with users remotely through a computer network,\par
-you should also make sure that it provides a way for users to get its source.\par
-For example, if your program is a web application, its interface could display\par
-a "Source" link that leads users to an archive of the code. There are many\par
-ways you could offer source, and different solutions will be better for different\par
-programs; see section 13 for the specific requirements.\par
-\par
-You should also get your employer (if you work as a programmer) or school,\par
-if any, to sign a "copyright disclaimer" for the program, if necessary. For\par
-more information on this, and how to apply and follow the GNU AGPL, see <{{\field{\*\fldinst{HYPERLINK "https://www.gnu.org/licenses/"}}{\fldrslt{https://www.gnu.org/licenses/\ul0\cf0}}}}\f0\fs16 >.\f2\par
-}
- 
+of liability accompanies a copy of the Program in return for a fee.\par


### PR DESCRIPTION
Seems to be some extra test that was not intended to be in the final EULA. This removes everything after the final entry.